### PR TITLE
refactor: improve efficiency in `isSublist`

### DIFF
--- a/AnomaHelpers.juvix
+++ b/AnomaHelpers.juvix
@@ -71,8 +71,9 @@ isNullifierPresent (nf : Nullifier) (tx : Transaction) : Bool :=
 isSubset {A} {{Ord A}} (sub sup : Set A) : Bool := all (x in Set.toList sub) Set.member? x sup;
 
 isSublist {A} {{Ord A}} (sub sup : List A) : Bool :=
-  all (x in sub)
-    Set.member? x (Set.fromList sup);
+  let sup' := Set.fromList sup
+  in all (x in sub)
+       Set.member? x sup';
 
 commitmentSet (tx : Transaction) : Set Commitment := Set.fromList (Transaction.commitments tx);
 


### PR DESCRIPTION
The compiler is not yet smart enough to figure out that `Set.fromList sup` does not change in the loop and lift it out. The list will be converted to a set repeatedly in each iteration, yielding quadratic complexity overall.

In general, it's safest to assume a "literal" translation: things get executed exactly at the point they occur. Also, applying constructors, creating pairs and other data types, partially applying functions, etc., always allocates memory for the data type / function closure at the point where this occurs in the program. Some things might be optimized away, but not much.
